### PR TITLE
Update s_net.h

### DIFF
--- a/src/s_net.h
+++ b/src/s_net.h
@@ -6,6 +6,15 @@
 
 #pragma once
 
+/* **********************************************************
+ * proposed compatiblity hotfix for MinGW/MSYS1 build system
+ *
+ * #define TEST_BOOLEAN_TRUE 1
+ * #define IPV6_V6ONLY TEST_BOOLEAN_TRUE
+ * #define _WIN32_WINNT 0x0600
+ *
+ */
+
 #ifdef _WIN32
 #include <winsock2.h>
 #include <ws2tcpip.h>


### PR DESCRIPTION
OK, so....

`#define IPV6_V6ONLY 1` gets rid of the undefined constant, while keeping the dual stack according to [IPV6 Socket Options (Microsoft Docs)](https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ipv6-socket-options).
`#define _WIN32_WINNT 0x0600` gets rid of the implicit declarations for socket functions.

The trick is **where** to put this; now I know `s_net.h` is the main header for network functions.

If you define _WIN32_WINNT in m_pd.h, it will produce a warning about redefinition relating to `sdkddkver.h` (under mingw root).

References

[Implicit declarations, Winsock, MinGW (StackOverflow)](https://stackoverflow.com/questions/12765743/implicit-declaration-of-function-getaddrinfo-on-mingw) 

[IPV6 Socket Options (Microsoft Docs)](https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ipv6-socket-options)